### PR TITLE
Revive Famsgiving for 2018

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,3 @@ end
 group :production do
   gem 'pg'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,9 +176,8 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console
 
 BUNDLED WITH
-   1.13.6
+   1.17.1


### PR DESCRIPTION
Reviving Famsgiving for 2018. Removing tzinfo-data because of warnings when running `bundle install`